### PR TITLE
Fix readme - "baseUrl" missing a quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ return [
     'modules' => [
         'rest-client' => [
             'class' => 'zhuravljov\yii\rest\Module',
-            'baseUrl => 'http://localhost/api/v1',
+            'baseUrl' => 'http://localhost/api/v1',
         ],
     ],
 ];


### PR DESCRIPTION
"baseUrl" missing a quote
