### PR TITLE
 Deprecate yii\base\Object

### DIFF
--- a/src/formatters/RawFormatter.php
+++ b/src/formatters/RawFormatter.php
@@ -2,7 +2,7 @@
 
 namespace zhuravljov\yii\rest\formatters;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\Html;
 
 /**
@@ -10,7 +10,7 @@ use yii\helpers\Html;
  *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
  */
-class RawFormatter extends Object
+class RawFormatter extends BaseObject
 {
     /**
      * @param \zhuravljov\yii\rest\models\ResponseRecord $record


### PR DESCRIPTION
yii\base\Object as object is reserved in php7